### PR TITLE
Refactor NuGet symbol package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ _ReSharper*/
 
 # NuGet Packages
 *.nupkg
+*.snupkg
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <VersionPrefix>0.0.5</VersionPrefix>
+    <VersionPrefix>0.0.6</VersionPrefix>
     <!--
       Only increment the assembly version on major version changes to help users reduce binding
       redirects, and how often they're updated. For more information, please read

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <VersionPrefix>0.0.6</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <!--
       Only increment the assembly version on major version changes to help users reduce binding
       redirects, and how often they're updated. For more information, please read

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <VersionPrefix>1.3.0</VersionPrefix>
+    <VersionPrefix>0.0.5</VersionPrefix>
     <!--
       Only increment the assembly version on major version changes to help users reduce binding
       redirects, and how often they're updated. For more information, please read

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,6 +32,7 @@ test: off
 
 artifacts:
   - path: ./artifacts/*.*nupkg
+    name: NuGet
     type: NuGetPackage
 
 deploy:
@@ -40,7 +41,7 @@ deploy:
     description: TODO
     auth_token:
       secure: de2wnJZf6k7NY0XriDpf9BkrQ4MR5ZfDDWMM+H/K4OK3w0GpuJAMRj5PrO6tKu0K
-    artifact: /.*\.nupkg/
+    artifact: NuGet
     draft: true
     on:
       APPVEYOR_REPO_TAG: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,6 +37,7 @@ artifacts:
 
 deploy:
   - provider: GitHub
+    tag: ${APPVEYOR_REPO_TAG_NAME}
     release: Release ${APPVEYOR_REPO_TAG_NAME}
     description: TODO
     auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,6 @@ test: off
 
 artifacts:
   - path: ./artifacts/*.*nupkg
-    name: NuGet
     type: NuGetPackage
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
 test: off
 
 artifacts:
-  - path: ./artifacts/*.nupkg
+  - path: ./artifacts/*.*nupkg
     name: NuGet
 
 deploy:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,6 +33,7 @@ test: off
 artifacts:
   - path: ./artifacts/*.*nupkg
     name: NuGet
+    type: NuGetPackage
 
 deploy:
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ deploy:
   - provider: NuGet
     api_key:
       secure: aSqd5YuYoWLJ0zxJRUA7libEne0t419Eoo1LWY+tEiX/p8hA4VhSymsBZJFjkvb1
+    symbol_server: https://www.nuget.org
     skip_symbols: false
     on:
       APPVEYOR_REPO_TAG: true

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -22,7 +22,7 @@ Write-Host "[build] dotnet cli v$(dotnet --version)"
 $VERSION_SUFFIX_ARG = If ($IS_TAGGED_BUILD -eq $true) { "" } Else { "--version-suffix=sha-$GIT_SHA" }
 dotnet build -c Release $VERSION_SUFFIX_ARG
 if ($LASTEXITCODE -ne 0) { exit 1 }
-dotnet pack -c Release --include-symbols -o ./../artifacts --no-build $VERSION_SUFFIX_ARG
+dotnet pack -c Release -o ./../artifacts --no-build $VERSION_SUFFIX_ARG
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
 # -------------------------------------------------------------------------------------------------

--- a/src/AwsSignatureVersion4.csproj
+++ b/src/AwsSignatureVersion4.csproj
@@ -15,7 +15,8 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <PackageReleaseNotes>For release notes, please see the change log on GitHub.</PackageReleaseNotes>
     <!-- Embed symbols in NuGet package -->
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <!-- SourceLink -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryUrl>https://github.com/FantasticFiasco/aws-signature-version-4.git</RepositoryUrl>


### PR DESCRIPTION
Update the build script to create a NuGet symbol package with the new `snupkg` format described in [Creating symbol packages (.snupkg)](https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg).

The symbols will from now on be pushed to NuGet instead of https://nuget.smbsrc.net, since we lately have had some problems with latter.