### PR TITLE
Fix missing NuGet package icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :syringe: Fixed
+
+- NuGet package does not show an icon
+
 ## [1.3.0] - 2020-06-29
 
 ### :zap: Added

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ build_script:
 test: off
 
 artifacts:
-  - path: ./artifacts/*.*nupkg
+  - path: artifacts/*.*nupkg
     name: NuGet
     type: NuGetPackage
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
   NODEJS_VERSION: "12"

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -22,7 +22,7 @@ Write-Host "[build] dotnet cli v$(dotnet --version)"
 $VERSION_SUFFIX_ARG = If ($IS_TAGGED_BUILD -eq $true) { "" } Else { "--version-suffix=sha-$GIT_SHA" }
 dotnet build -c Release $VERSION_SUFFIX_ARG
 if ($LASTEXITCODE -ne 0) { exit 1 }
-dotnet pack -c Release -o ./../artifacts --no-build $VERSION_SUFFIX_ARG
+dotnet pack -c Release -o ./artifacts --no-build $VERSION_SUFFIX_ARG
 if ($LASTEXITCODE -ne 0) { exit 1 }
 
 # -------------------------------------------------------------------------------------------------

--- a/src/AwsSignatureVersion4.csproj
+++ b/src/AwsSignatureVersion4.csproj
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Include="assets\aws-signature-version-4.png" Pack="true" PackagePath="\"/>
+    <None Include="assets\aws-signature-version-4.png" Pack="true" PackagePath=""/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
NuGet package published to [www.nuget.org](https://www.nuget.org/packages/AwsSignatureVersion4/) does not show a package icon.