### PR TITLE
Configure SourceLink to use deterministic builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 - NuGet package does not show an icon
 - Configure [SourceLink](https://github.com/dotnet/sourcelink) to embed untracked sources
+- Configure [SourceLink](https://github.com/dotnet/sourcelink) to use deterministic builds when running on AppVeyor
 
 ## [1.3.0] - 2020-06-29
 

--- a/src/AwsSignatureVersion4.csproj
+++ b/src/AwsSignatureVersion4.csproj
@@ -17,16 +17,10 @@
     <!-- Embed symbols in NuGet package -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <!-- SourceLink -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RepositoryUrl>https://github.com/FantasticFiasco/aws-signature-version-4.git</RepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.Core" Version="3.3.101.15" />
-    <!-- SourceLink -->
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45' Or '$(TargetFramework)' == 'net461'">
@@ -40,6 +34,22 @@
 
   <ItemGroup>
     <None Include="assets\aws-signature-version-4.png" Pack="true" PackagePath=""/>
+  </ItemGroup>
+
+  <!-- SourceLink -->
+
+  <PropertyGroup>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <RepositoryUrl>https://github.com/FantasticFiasco/aws-signature-version-4.git</RepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(CI)' == 'True'">
+    <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Configure SourceLink to use deterministic builds when running on AppVeyor.