### PR TITLE
Configure Renovate to accept AWSSDK.* NuGet packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,11 @@
     {
       "packagePatterns": ["^@aws-cdk", "^aws-cdk"],
       "groupName": "AWS CDK packages"
+    },
+    {
+      "datasources": ["nuget"],
+      "packagePatterns": ["^AWSSDK."],
+      "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)\\.(?<prerelease>.*)$"
     }
   ]
 }


### PR DESCRIPTION
The `AWSSDK.*` NuGet packages are not adhering to semver, thus is in need of special configuration.