### PR TITLE
Migrate from CodeCov bash script to CodeCov Uploader

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,9 +34,8 @@ artifacts:
   - path: artifacts/*.*nupkg
     name: NuGet
     type: NuGetPackage
-  - path: ./test/TestResults/*
+  - path: test/TestResults/*/coverage.cobertura.xml
     name: Code coverage
-    type: zip
 
 deploy:
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,8 +34,6 @@ artifacts:
   - path: artifacts/*.*nupkg
     name: NuGet
     type: NuGetPackage
-  - path: test/TestResults/*/coverage.cobertura.xml
-    name: Code coverage
 
 deploy:
   - provider: GitHub

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ artifacts:
   - path: artifacts/*.*nupkg
     name: NuGet
     type: NuGetPackage
-  - path: test/TestResults
+  - path: ./test/TestResults/*
     name: Code coverage
     type: zip
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,9 @@ artifacts:
   - path: artifacts/*.*nupkg
     name: NuGet
     type: NuGetPackage
+  - path: test/TestResults
+    name: Code coverage
+    type: zip
 
 deploy:
   - provider: GitHub

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -59,27 +59,17 @@ else {
     Print "test" "download codecov uploader"
     Invoke-WebRequest -Uri https://uploader.codecov.io/latest/codecov.exe -Outfile codecov.exe
 
-    foreach ($testResult in Get-ChildItem .\test\TestResults\*)
+    foreach ($test_result in Get-ChildItem .\test\TestResults\*)
     {
-        #Push-Location $testResult
-        $file_path = Split-Path -Path $testResult -Leaf -Resolve
-        $file_path = ".\test\TestResults\$file_path\coverage.cobertura.xml"
+        $relative_test_result = $test_result | Resolve-Path -Relative
 
+        // CodeCode uploader cant handle "\", thus we have to replace these with "/"
+        $relative_test_result = $relative_test_result -Replace "\\", "/"
 
+        Print "test" "upload coverage report $relative_test_result"
 
-
-        Print "test" "upload coverage report $file_path"
-
-
-        #$temp = Join-Path -Path $testResult -ChildPath "coverage.cobertura.xml"
-        #Print "$temp"
-
-        #Get-ChildItem
-        # .\codecov.exe -f .\coverage.cobertura.xml
-        .\codecov.exe -f $file_path
+        .\codecov.exe -f $relative_test_result
         if ($LASTEXITCODE -ne 0) { exit 1 }
-
-        Pop-Location
     }
 }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -65,7 +65,9 @@ else {
         Get-ChildItem
 
         Print "test" "upload coverage report from $testResult"
-        # Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
+        Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
+
+        Get-ChildItem
         # .\codecov.exe -f "coverage.cobertura.xml"
         if ($LASTEXITCODE -ne 0) { exit 1 }
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -59,7 +59,7 @@ else {
     Print "test" "download codecov uploader"
     Invoke-WebRequest -Uri https://uploader.codecov.io/latest/codecov.exe -Outfile codecov.exe
 
-    foreach ($test_result in Get-ChildItem .\test\TestResults\*)
+    foreach ($test_result in Get-ChildItem .\test\TestResults\*\coverage.cobertura.xml)
     {
         $relative_test_result = $test_result | Resolve-Path -Relative
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -63,7 +63,7 @@ else {
     {
         #Push-Location $testResult
         $file_path = Split-Path -Path $testResult -Leaf -Resolve
-        $file_path = ".\test\TestResults\$file_path\coverage.cobertura.xml"
+        $file_path = "test\\TestResults\\$file_path\\coverage.cobertura.xml"
 
 
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -63,7 +63,7 @@ else {
     {
         #Push-Location $testResult
         $file_path = Split-Path -Path $testResult -Leaf -Resolve
-        $file_path = "test\\TestResults\\$file_path\\coverage.cobertura.xml"
+        $file_path = ".\test\TestResults\$file_path\coverage.cobertura.xml"
 
 
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -67,8 +67,12 @@ else {
         Print "test" "upload coverage report from $testResult"
         Invoke-WebRequest -Uri https://uploader.codecov.io/latest/codecov.exe -Outfile codecov.exe
 
+        $temp = Join-Path -Path $testResult -ChildPath "coverage.cobertura.xml"
+        Print "$temp"
+
         Get-ChildItem
-        .\codecov.exe -f .\coverage.cobertura.xml
+        # .\codecov.exe -f .\coverage.cobertura.xml
+        .\codecov.exe -f $temp
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -65,10 +65,10 @@ else {
         Get-ChildItem
 
         Print "test" "upload coverage report from $testResult"
-        Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
+        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/codecov.exe -Outfile codecov.exe
 
         Get-ChildItem
-        # .\codecov.exe -f "coverage.cobertura.xml"
+        .\codecov.exe -f .\coverage.cobertura.xml
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -56,23 +56,29 @@ else {
     dotnet test -c Release --no-build --collect:"XPlat Code Coverage"
     if ($LASTEXITCODE -ne 0) { exit 1 }
 
+    Print "test" "download codecov uploader"
+    Invoke-WebRequest -Uri https://uploader.codecov.io/latest/codecov.exe -Outfile codecov.exe
+
     foreach ($testResult in Get-ChildItem .\test\TestResults\*)
     {
-        Push-Location $testResult
+        #Push-Location $testResult
+        $temp = Split-Path -Path $testResult -Leaf -Resolve
+        Write-Host $temp
 
-        Print "Test result dir: $testResult"
-        Get-Location
-        Get-ChildItem
+        $temp = "test\TestResults\$temp"
+        Write-Host $temp
 
-        Print "test" "upload coverage report from $testResult"
-        Invoke-WebRequest -Uri https://uploader.codecov.io/latest/codecov.exe -Outfile codecov.exe
 
-        $temp = Join-Path -Path $testResult -ChildPath "coverage.cobertura.xml"
-        Print "$temp"
 
-        Get-ChildItem
+        # Print "test" "upload coverage report from $testResult"
+
+
+        #$temp = Join-Path -Path $testResult -ChildPath "coverage.cobertura.xml"
+        #Print "$temp"
+
+        #Get-ChildItem
         # .\codecov.exe -f .\coverage.cobertura.xml
-        .\codecov.exe -f $temp
+        #.\codecov.exe -f $temp
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -60,9 +60,13 @@ else {
     {
         Push-Location $testResult
 
+        Print "Test result dir: $testResult"
+        Get-Location
+        Get-ChildItem
+
         Print "test" "upload coverage report from $testResult"
-        Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
-        .\codecov.exe -f "coverage.cobertura.xml"
+        # Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
+        # .\codecov.exe -f "coverage.cobertura.xml"
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -62,7 +62,7 @@ else {
 
         Print "test" "upload coverage report from $testResult"
         Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
-        codecov.exe -f "coverage.cobertura.xml"
+        .\codecov.exe -f "coverage.cobertura.xml"
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -63,7 +63,7 @@ else {
     {
         #Push-Location $testResult
         $file_path = Split-Path -Path $testResult -Leaf -Resolve
-        $file_path = "test\TestResults\$file_path\coverage.cobertura.xml"
+        $file_path = ".\test\TestResults\$file_path\coverage.cobertura.xml"
 
 
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -62,15 +62,13 @@ else {
     foreach ($testResult in Get-ChildItem .\test\TestResults\*)
     {
         #Push-Location $testResult
-        $temp = Split-Path -Path $testResult -Leaf -Resolve
+        $file_path = Split-Path -Path $testResult -Leaf -Resolve
+        $file_path = "test\TestResults\$temp"
         Write-Host $temp
 
-        $temp = "test\TestResults\$temp"
-        Write-Host $temp
 
 
-
-        # Print "test" "upload coverage report from $testResult"
+        Print "test" "upload coverage report $file_path"
 
 
         #$temp = Join-Path -Path $testResult -ChildPath "coverage.cobertura.xml"
@@ -78,7 +76,7 @@ else {
 
         #Get-ChildItem
         # .\codecov.exe -f .\coverage.cobertura.xml
-        #.\codecov.exe -f $temp
+        .\codecov.exe -f $file_path
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -63,8 +63,8 @@ else {
     {
         #Push-Location $testResult
         $file_path = Split-Path -Path $testResult -Leaf -Resolve
-        $file_path = "test\TestResults\$temp"
-        Write-Host $temp
+        $file_path = "test\TestResults\$file_path"
+
 
 
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -63,7 +63,7 @@ else {
     {
         #Push-Location $testResult
         $file_path = Split-Path -Path $testResult -Leaf -Resolve
-        $file_path = "test\TestResults\$file_path"
+        $file_path = "test\TestResults\$file_path\coverage.cobertura.xml"
 
 
 

--- a/build/build.ps1
+++ b/build/build.ps1
@@ -61,8 +61,8 @@ else {
         Push-Location $testResult
 
         Print "test" "upload coverage report from $testResult"
-        Invoke-WebRequest -Uri "https://codecov.io/bash" -OutFile codecov.sh
-        bash codecov.sh -f "coverage.cobertura.xml"
+        Invoke-WebRequest -Uri "https://uploader.codecov.io/latest/codecov.exe" -Outfile codecov.exe
+        codecov.exe -f "coverage.cobertura.xml"
         if ($LASTEXITCODE -ne 0) { exit 1 }
 
         Pop-Location


### PR DESCRIPTION
CodeCov has released a replacement for the bash script, the [CodeCov Uploader](https://about.codecov.io/blog/introducing-codecovs-new-uploader/), let's migrate.