### PR TITLE
AwsSignatureHandler now overrides the synchronous Send() method in .NET 5.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/) and is followi
 
 ## Unreleased
 
+### :syringe: Fixed
+
+- [#478](https://github.com/FantasticFiasco/aws-signature-version-4/issues/478) Add support for `HttpClient.Send` on .NET 5 (contribution by [@Timovzl](https://github.com/Timovzl))
+
 ## [2.1.0] - 2021-08-29
 
 ### :zap: Added

--- a/src/AwsSignatureHandler.cs
+++ b/src/AwsSignatureHandler.cs
@@ -24,7 +24,7 @@ namespace AwsSignatureVersion4
     public class AwsSignatureHandler : DelegatingHandler
     {
         private static readonly KeyValuePair<string, IEnumerable<string>>[] EmptyRequestHeaders =
-            Array.Empty<KeyValuePair<string, IEnumerable<string>>>();
+            new KeyValuePair<string, IEnumerable<string>>[0];
 
         private readonly AwsSignatureHandlerSettings settings;
 

--- a/src/AwsSignatureVersion4.csproj
+++ b/src/AwsSignatureVersion4.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>The buttoned-up and boring, but deeply analyzed, implementation of Signature Version 4 (SigV4) in .NET.</Description>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;net5.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>

--- a/src/Private/CanonicalRequest.cs
+++ b/src/Private/CanonicalRequest.cs
@@ -54,7 +54,7 @@ namespace AwsSignatureVersion4.Private
             // URI-encoded twice (
             // <see href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html">
             // except for Amazon S3 which only gets URI-encoded once</see>).
-            var canonicalResourcePath = GetCanonicalResourcePath(serviceName, request.RequestUri);
+            var canonicalResourcePath = GetCanonicalResourcePath(serviceName, request.RequestUri!);
 
             builder.Append($"{canonicalResourcePath}\n");
 
@@ -81,7 +81,7 @@ namespace AwsSignatureVersion4.Private
             //    string for parameters that have no value.
             // e. Append the ampersand character (&) after each parameter value, except for the
             //    last value in the list.
-            var parameters = SortQueryParameters(request.RequestUri.Query)
+            var parameters = SortQueryParameters(request.RequestUri!.Query)
                 .SelectMany(
                     parameter => parameter.Value.Select(
                         parameterValue => $"{AWSSDKUtils.UrlEncode(parameter.Key, false)}={AWSSDKUtils.UrlEncode(parameterValue, false)}"));
@@ -166,7 +166,12 @@ namespace AwsSignatureVersion4.Private
                     sortedQueryParameters.Add(parameterName, parameterValues);
                 }
 
-                parameterValues.AddRange(queryParameters.GetValues(parameterName));
+                parameterValues.AddRange(queryParameters.GetValues(parameterName) ??
+#if NET45
+                    new string[0]);
+#else
+                    Array.Empty<string>());
+#endif
             }
 
             // Sort the query parameter values

--- a/src/Private/CanonicalRequest.cs
+++ b/src/Private/CanonicalRequest.cs
@@ -39,6 +39,8 @@ namespace AwsSignatureVersion4.Private
             IEnumerable<KeyValuePair<string, IEnumerable<string>>> defaultHeaders,
             string contentHash)
         {
+            if (request.RequestUri == null) throw new InvalidOperationException(ErrorMessages.InvalidRequestUri);
+
             var builder = new StringBuilder();
 
             // The HTTP request method (GET, PUT, POST, etc.), followed by a newline character
@@ -54,7 +56,7 @@ namespace AwsSignatureVersion4.Private
             // URI-encoded twice (
             // <see href="https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html">
             // except for Amazon S3 which only gets URI-encoded once</see>).
-            var canonicalResourcePath = GetCanonicalResourcePath(serviceName, request.RequestUri!);
+            var canonicalResourcePath = GetCanonicalResourcePath(serviceName, request.RequestUri);
 
             builder.Append($"{canonicalResourcePath}\n");
 

--- a/src/Private/CanonicalRequest.cs
+++ b/src/Private/CanonicalRequest.cs
@@ -19,7 +19,7 @@ namespace AwsSignatureVersion4.Private
         /// <summary>
         /// Gets or sets an instance capable of probing the environment.
         /// </summary>
-        public static EnvironmentProbe EnvironmentProbe { get; set; } = new EnvironmentProbe();
+        public static EnvironmentProbe EnvironmentProbe { get; set; } = new();
 
         /// <summary>
         /// Gets or sets the header value separator. The default value is ", " and it is defined in

--- a/src/Private/CanonicalRequest.cs
+++ b/src/Private/CanonicalRequest.cs
@@ -168,12 +168,11 @@ namespace AwsSignatureVersion4.Private
                     sortedQueryParameters.Add(parameterName, parameterValues);
                 }
 
-                parameterValues.AddRange(queryParameters.GetValues(parameterName) ??
-#if NET45
-                    new string[0]);
-#else
-                    Array.Empty<string>());
-#endif
+                var queryParameterValues = queryParameters.GetValues(parameterName);
+                if (queryParameterValues?.Length > 0)
+                {
+                    parameterValues.AddRange(queryParameterValues);
+                }
             }
 
             // Sort the query parameter values

--- a/src/Private/CanonicalRequest.cs
+++ b/src/Private/CanonicalRequest.cs
@@ -83,7 +83,7 @@ namespace AwsSignatureVersion4.Private
             //    string for parameters that have no value.
             // e. Append the ampersand character (&) after each parameter value, except for the
             //    last value in the list.
-            var parameters = SortQueryParameters(request.RequestUri!.Query)
+            var parameters = SortQueryParameters(request.RequestUri.Query)
                 .SelectMany(
                     parameter => parameter.Value.Select(
                         parameterValue => $"{AWSSDKUtils.UrlEncode(parameter.Key, false)}={AWSSDKUtils.UrlEncode(parameterValue, false)}"));

--- a/src/Private/ContentHash.cs
+++ b/src/Private/ContentHash.cs
@@ -11,6 +11,7 @@ namespace AwsSignatureVersion4.Private
     /// </summary>
     public static class ContentHash
     {
+        /// <remarks>This method has a synchronous alternative.</remarks>
         public static async Task<string> CalculateAsync(HttpContent? content)
         {
             // Use a hash (digest) function like SHA256 to create a hashed value from the payload
@@ -31,6 +32,7 @@ namespace AwsSignatureVersion4.Private
 
 #if NET5_0_OR_GREATER
 
+        /// <remarks>This method has a asynchronous alternative.</remarks>
         public static string Calculate(HttpContent? content)
         {
             // Use a hash (digest) function like SHA256 to create a hashed value from the payload
@@ -48,6 +50,7 @@ namespace AwsSignatureVersion4.Private
             var hash = CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(contentStream);
             return AWSSDKUtils.ToHex(hash, true);
         }
+
 #endif
     }
 }

--- a/src/Private/ContentHash.cs
+++ b/src/Private/ContentHash.cs
@@ -1,5 +1,4 @@
-﻿using System.IO;
-using System.Net.Http;
+﻿using System.Net.Http;
 using System.Threading.Tasks;
 using Amazon.Runtime.Internal.Auth;
 using Amazon.Util;
@@ -25,8 +24,8 @@ namespace AwsSignatureVersion4.Private
                 return AWS4Signer.EmptyBodySha256;
             }
 
-            var data = await content.ReadAsByteArrayAsync();
-            var hash = AWS4Signer.ComputeHash(data);
+            var contentStream = await content.ReadAsStreamAsync();
+            var hash = CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(contentStream);
             return AWSSDKUtils.ToHex(hash, true);
         }
 
@@ -45,12 +44,10 @@ namespace AwsSignatureVersion4.Private
                 return AWS4Signer.EmptyBodySha256;
             }
 
-            // AWS4Signer.ComputeHash() simply calls CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(), but omits a Stream-based overload
-            var stream = content.ReadAsStream();
-            var hash = CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(stream);
+            var contentStream = content.ReadAsStream();
+            var hash = CryptoUtilFactory.CryptoInstance.ComputeSHA256Hash(contentStream);
             return AWSSDKUtils.ToHex(hash, true);
         }
-
 #endif
     }
 }

--- a/src/Private/Extensions.cs
+++ b/src/Private/Extensions.cs
@@ -13,7 +13,7 @@ namespace AwsSignatureVersion4.Private
         /// <summary>
         /// Converts string into an instance of an <see cref="Uri"/>.
         /// </summary>
-        public static Uri ToUri(this string self) => new Uri(self, UriKind.RelativeOrAbsolute);
+        public static Uri ToUri(this string self) => new(self, UriKind.RelativeOrAbsolute);
 
         /// <summary>
         /// Normalize string by reducing multiple sequential whitespaces into a single space.

--- a/src/Private/System/Web/HttpUtility.cs
+++ b/src/Private/System/Web/HttpUtility.cs
@@ -57,7 +57,7 @@ namespace System.Web
                     return "";
                 }
 
-                StringBuilder sb = new StringBuilder();
+                StringBuilder sb = new();
                 string?[] keys = AllKeys;
                 for (int i = 0; i < count; i++)
                 {
@@ -96,7 +96,7 @@ namespace System.Web
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            HttpQSCollection result = new HttpQSCollection();
+            HttpQSCollection result = new();
             int queryLength = query.Length;
             int namePos = queryLength > 0 && query[0] == '?' ? 1 : 0;
             if (queryLength == namePos)

--- a/src/Private/System/Web/HttpUtility.cs
+++ b/src/Private/System/Web/HttpUtility.cs
@@ -57,7 +57,7 @@ namespace System.Web
                     return "";
                 }
 
-                StringBuilder sb = new();
+                var sb = new StringBuilder();
                 string?[] keys = AllKeys;
                 for (int i = 0; i < count; i++)
                 {
@@ -96,7 +96,7 @@ namespace System.Web
                 throw new ArgumentNullException(nameof(encoding));
             }
 
-            HttpQSCollection result = new();
+            var result = new HttpQSCollection();
             int queryLength = query.Length;
             int namePos = queryLength > 0 && query[0] == '?' ? 1 : 0;
             if (queryLength == namePos)

--- a/src/Private/System/Web/Util/HttpEncoder.cs
+++ b/src/Private/System/Web/Util/HttpEncoder.cs
@@ -16,7 +16,7 @@ namespace System.Web.Util
         internal static string UrlDecode(string value, Encoding encoding)
         {
             int count = value.Length;
-            UrlDecoder helper = new UrlDecoder(count, encoding);
+            UrlDecoder helper = new(count, encoding);
 
             // go through the string's chars collapsing %XX and %uXXXX and
             // appending each char as char, with exception of %XX constructs

--- a/src/SendAsyncExtensions.cs
+++ b/src/SendAsyncExtensions.cs
@@ -511,5 +511,470 @@ namespace System.Net.Http
         }
 
         #endregion
+
+#if NET5_0_OR_GREATER
+
+        #region Send(HttpRequestMessage, string, string, <credentials>)
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            string regionName,
+            string serviceName,
+            AWSCredentials credentials) =>
+            self.Send(
+                request,
+                DefaultCompletionOption,
+                CancellationToken.None,
+                regionName,
+                serviceName,
+                credentials);
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            string regionName,
+            string serviceName,
+            ImmutableCredentials credentials) =>
+            self.Send(
+                request,
+                DefaultCompletionOption,
+                CancellationToken.None,
+                regionName,
+                serviceName,
+                credentials);
+
+        #endregion
+
+        #region Send(HttpRequestMessage, HttpCompletionOption, string, string, <credentials>)
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="completionOption">
+        /// When the operation should complete (as soon as a response is available or after reading
+        /// the whole response content).
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            string regionName,
+            string serviceName,
+            AWSCredentials credentials) =>
+            self.Send(
+                request,
+                completionOption,
+                CancellationToken.None,
+                regionName,
+                serviceName,
+                credentials);
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="completionOption">
+        /// When the operation should complete (as soon as a response is available or after reading
+        /// the whole response content).
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            string regionName,
+            string serviceName,
+            ImmutableCredentials credentials) =>
+            self.Send(
+                request,
+                completionOption,
+                CancellationToken.None,
+                regionName,
+                serviceName,
+                credentials);
+
+        #endregion
+
+        #region Send(HttpRequestMessage, CancellationToken, string, string, <credentials>)
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancellation token to cancel operation.
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            CancellationToken cancellationToken,
+            string regionName,
+            string serviceName,
+            AWSCredentials credentials) =>
+            self.Send(
+                request,
+                DefaultCompletionOption,
+                cancellationToken,
+                regionName,
+                serviceName,
+                credentials);
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancellation token to cancel operation.
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            CancellationToken cancellationToken,
+            string regionName,
+            string serviceName,
+            ImmutableCredentials credentials) =>
+            self.Send(
+                request,
+                DefaultCompletionOption,
+                cancellationToken,
+                regionName,
+                serviceName,
+                credentials);
+
+        #endregion
+
+        #region Send(HttpRequestMessage, HttpCompletionOption, CancellationToken, string, string, <credentials>)
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="completionOption">
+        /// When the operation should complete (as soon as a response is available or after reading
+        /// the whole response content).
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancellation token to cancel operation.
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            CancellationToken cancellationToken,
+            string regionName,
+            string serviceName,
+            AWSCredentials credentials)
+        {
+            if (credentials == null) throw new ArgumentNullException(nameof(credentials));
+
+            var immutableCredentials = credentials.GetCredentials();
+
+            var response = self.Send(
+                request,
+                completionOption,
+                cancellationToken,
+                regionName,
+                serviceName,
+                immutableCredentials);
+
+            return response;
+        }
+
+        /// <summary>
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// </summary>
+        /// <param name="self">
+        /// The extension target.
+        /// </param>
+        /// <param name="request">
+        /// The HTTP request message to send.
+        /// </param>
+        /// <param name="completionOption">
+        /// When the operation should complete (as soon as a response is available or after reading
+        /// the whole response content).
+        /// </param>
+        /// <param name="cancellationToken">
+        /// The cancellation token to cancel operation.
+        /// </param>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        /// <param name="credentials">
+        /// AWS credentials containing the following parameters:
+        /// - The AWS public key for the account making the service call.
+        /// - The AWS secret key for the account making the call, in clear text.
+        /// - The session token obtained from STS if request is authenticated using temporary
+        ///   security credentials, e.g. a role.
+        /// </param>
+        /// <returns>
+        /// The response message.
+        /// </returns>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="request"/> is null.
+        /// </exception>
+        /// <exception cref="InvalidOperationException">
+        /// The request message was already sent by the <see cref="HttpClient"/> instance.
+        /// </exception>
+        /// <exception cref="HttpRequestException">
+        /// The request failed due to an underlying issue such as network connectivity, DNS
+        /// failure, server certificate validation or timeout.
+        /// </exception>
+        public static HttpResponseMessage Send(
+            this HttpClient self,
+            HttpRequestMessage request,
+            HttpCompletionOption completionOption,
+            CancellationToken cancellationToken,
+            string regionName,
+            string serviceName,
+            ImmutableCredentials credentials)
+        {
+            if (self == null) throw new ArgumentNullException(nameof(self));
+
+            var signingTask = Signer.SignAsync(
+                request,
+                self.BaseAddress,
+                self.DefaultRequestHeaders,
+                DateTime.UtcNow,
+                regionName,
+                serviceName,
+                credentials);
+
+            System.Diagnostics.Debug.Assert(signingTask.IsCompletedSuccessfully, "The operation should have completed synchronously.");
+
+            return self.Send(request, completionOption, cancellationToken);
+        }
+
+        #endregion
+
+#endif
     }
 }

--- a/src/SendExtensions.cs
+++ b/src/SendExtensions.cs
@@ -38,7 +38,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -91,7 +91,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -152,7 +152,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -210,7 +210,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -271,7 +271,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -332,7 +332,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -401,7 +401,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -475,7 +475,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The response message.
+        /// The HTTP response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.

--- a/src/SendExtensions.cs
+++ b/src/SendExtensions.cs
@@ -1,8 +1,9 @@
-﻿using System.Threading;
+﻿#if NET5_0_OR_GREATER
+
+using System.Threading;
+using System.Threading.Tasks;
 using Amazon.Runtime;
 using AwsSignatureVersion4.Private;
-
-#if NET5_0_OR_GREATER
 
 // ReSharper disable once CheckNamespace
 namespace System.Net.Http
@@ -15,7 +16,7 @@ namespace System.Net.Http
         #region Send(HttpRequestMessage, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -41,13 +42,17 @@ namespace System.Net.Http
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
-        /// </exception>
+        /// </exception> 
         /// <exception cref="InvalidOperationException">
         /// The request message was already sent by the <see cref="HttpClient"/> instance.
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -64,7 +69,7 @@ namespace System.Net.Http
                 credentials);
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -96,7 +101,11 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -117,7 +126,7 @@ namespace System.Net.Http
         #region Send(HttpRequestMessage, HttpCompletionOption, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -126,8 +135,8 @@ namespace System.Net.Http
         /// The HTTP request message to send.
         /// </param>
         /// <param name="completionOption">
-        /// When the operation should complete (as soon as a response is available or after reading
-        /// the whole response content).
+        /// One of the enumeration values that specifies when the operation should complete (as
+        /// soon as a response is available or after reading the response content).
         /// </param>
         /// <param name="regionName">
         /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
@@ -153,7 +162,11 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -171,7 +184,7 @@ namespace System.Net.Http
                 credentials);
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -180,8 +193,8 @@ namespace System.Net.Http
         /// The HTTP request message to send.
         /// </param>
         /// <param name="completionOption">
-        /// When the operation should complete (as soon as a response is available or after reading
-        /// the whole response content).
+        /// One of the enumeration values that specifies when the operation should complete (as
+        /// soon as a response is available or after reading the response content).
         /// </param>
         /// <param name="regionName">
         /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
@@ -207,7 +220,11 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -229,7 +246,7 @@ namespace System.Net.Http
         #region Send(HttpRequestMessage, CancellationToken, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -264,7 +281,15 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// The request was canceled.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -282,7 +307,7 @@ namespace System.Net.Http
                 credentials);
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -317,7 +342,15 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// The request was canceled.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -339,7 +372,7 @@ namespace System.Net.Http
         #region Send(HttpRequestMessage, HttpCompletionOption, CancellationToken, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -348,8 +381,8 @@ namespace System.Net.Http
         /// The HTTP request message to send.
         /// </param>
         /// <param name="completionOption">
-        /// When the operation should complete (as soon as a response is available or after reading
-        /// the whole response content).
+        /// One of the enumeration values that specifies when the operation should complete (as
+        /// soon as a response is available or after reading the response content).
         /// </param>
         /// <param name="cancellationToken">
         /// The cancellation token to cancel operation.
@@ -378,7 +411,15 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// The request was canceled.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -405,7 +446,7 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
+        /// Send an Signature Version 4 signed HTTP request.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -414,8 +455,8 @@ namespace System.Net.Http
         /// The HTTP request message to send.
         /// </param>
         /// <param name="completionOption">
-        /// When the operation should complete (as soon as a response is available or after reading
-        /// the whole response content).
+        /// One of the enumeration values that specifies when the operation should complete (as
+        /// soon as a response is available or after reading the response content).
         /// </param>
         /// <param name="cancellationToken">
         /// The cancellation token to cancel operation.
@@ -444,7 +485,15 @@ namespace System.Net.Http
         /// </exception>
         /// <exception cref="HttpRequestException">
         /// The request failed due to an underlying issue such as network connectivity, DNS
-        /// failure, server certificate validation or timeout.
+        /// failure, or server certificate validation.
+        /// </exception>
+        /// <exception cref="TaskCanceledException">
+        /// The request was canceled.
+        /// <para/>
+        /// -or-
+        /// <para/>
+        /// If the <see cref="TaskCanceledException"/> exception nests the
+        /// <see cref="TimeoutException"/>: The request failed due to timeout.
         /// </exception>
         public static HttpResponseMessage Send(
             this HttpClient self,
@@ -457,7 +506,7 @@ namespace System.Net.Http
         {
             if (self == null) throw new ArgumentNullException(nameof(self));
 
-            var signingTask = Signer.SignAsync(
+            Signer.Sign(
                 request,
                 self.BaseAddress,
                 self.DefaultRequestHeaders,
@@ -465,8 +514,6 @@ namespace System.Net.Http
                 regionName,
                 serviceName,
                 credentials);
-
-            System.Diagnostics.Debug.Assert(signingTask.IsCompletedSuccessfully, "The operation should have completed synchronously.");
 
             return self.Send(request, completionOption, cancellationToken);
         }

--- a/src/SendExtensions.cs
+++ b/src/SendExtensions.cs
@@ -1,7 +1,8 @@
 ﻿using System.Threading;
-using System.Threading.Tasks;
 using Amazon.Runtime;
 using AwsSignatureVersion4.Private;
+
+#if NET5_0_OR_GREATER
 
 // ReSharper disable once CheckNamespace
 namespace System.Net.Http
@@ -9,14 +10,12 @@ namespace System.Net.Http
     /// <summary>
     /// Extensions to <see cref="HttpClient"/> extending it to support AWS Signature Version 4.
     /// </summary>
-    public static class SendAsyncExtensions
+    public static class SendExtensions
     {
-        internal const HttpCompletionOption DefaultCompletionOption = HttpCompletionOption.ResponseContentRead;
-
-        #region SendAsync(HttpRequestMessage, string, string, <credentials>)
+        #region Send(HttpRequestMessage, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -38,7 +37,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -50,26 +49,22 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. The returned <see cref="Task{TResult}"/> object will
-        /// complete once the entire response including content is read.
-        /// </remarks>
-        public static Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             string regionName,
             string serviceName,
             AWSCredentials credentials) =>
-            self.SendAsync(
+            self.Send(
                 request,
-                DefaultCompletionOption,
+                SendAsyncExtensions.DefaultCompletionOption,
                 CancellationToken.None,
                 regionName,
                 serviceName,
                 credentials);
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -91,7 +86,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -103,19 +98,15 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. The returned <see cref="Task{TResult}"/> object will
-        /// complete once the entire response including content is read.
-        /// </remarks>
-        public static Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             string regionName,
             string serviceName,
             ImmutableCredentials credentials) =>
-            self.SendAsync(
+            self.Send(
                 request,
-                DefaultCompletionOption,
+                SendAsyncExtensions.DefaultCompletionOption,
                 CancellationToken.None,
                 regionName,
                 serviceName,
@@ -123,10 +114,10 @@ namespace System.Net.Http
 
         #endregion
 
-        #region SendAsync(HttpRequestMessage, HttpCompletionOption, string, string, <credentials>)
+        #region Send(HttpRequestMessage, HttpCompletionOption, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -152,7 +143,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -164,20 +155,14 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. Depending on the value of the
-        /// <paramref name="completionOption"/> parameter, the returned <see cref="Task{TResult}"/>
-        /// object will complete as soon as a response is available or the entire response
-        /// including content is read.
-        /// </remarks>
-        public static Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             HttpCompletionOption completionOption,
             string regionName,
             string serviceName,
             AWSCredentials credentials) =>
-            self.SendAsync(
+            self.Send(
                 request,
                 completionOption,
                 CancellationToken.None,
@@ -186,7 +171,7 @@ namespace System.Net.Http
                 credentials);
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -212,7 +197,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -224,20 +209,14 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. Depending on the value of the
-        /// <paramref name="completionOption"/> parameter, the returned <see cref="Task{TResult}"/>
-        /// object will complete as soon as a response is available or the entire response
-        /// including content is read.
-        /// </remarks>
-        public static Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             HttpCompletionOption completionOption,
             string regionName,
             string serviceName,
             ImmutableCredentials credentials) =>
-            self.SendAsync(
+            self.Send(
                 request,
                 completionOption,
                 CancellationToken.None,
@@ -247,10 +226,10 @@ namespace System.Net.Http
 
         #endregion
 
-        #region SendAsync(HttpRequestMessage, CancellationToken, string, string, <credentials>)
+        #region Send(HttpRequestMessage, CancellationToken, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -275,7 +254,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -287,27 +266,23 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. The returned <see cref="Task{TResult}"/> object will
-        /// complete once the entire response including content is read.
-        /// </remarks>
-        public static Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             CancellationToken cancellationToken,
             string regionName,
             string serviceName,
             AWSCredentials credentials) =>
-            self.SendAsync(
+            self.Send(
                 request,
-                DefaultCompletionOption,
+                SendAsyncExtensions.DefaultCompletionOption,
                 cancellationToken,
                 regionName,
                 serviceName,
                 credentials);
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -332,7 +307,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -344,20 +319,16 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. The returned <see cref="Task{TResult}"/> object will
-        /// complete once the entire response including content is read.
-        /// </remarks>
-        public static Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             CancellationToken cancellationToken,
             string regionName,
             string serviceName,
             ImmutableCredentials credentials) =>
-            self.SendAsync(
+            self.Send(
                 request,
-                DefaultCompletionOption,
+                SendAsyncExtensions.DefaultCompletionOption,
                 cancellationToken,
                 regionName,
                 serviceName,
@@ -365,10 +336,10 @@ namespace System.Net.Http
 
         #endregion
 
-        #region SendAsync(HttpRequestMessage, HttpCompletionOption, CancellationToken, string, string, <credentials>)
+        #region Send(HttpRequestMessage, HttpCompletionOption, CancellationToken, string, string, <credentials>)
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -397,7 +368,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -409,13 +380,7 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. Depending on the value of the
-        /// <paramref name="completionOption"/> parameter, the returned <see cref="Task{TResult}"/>
-        /// object will complete as soon as a response is available or the entire response
-        /// including content is read.
-        /// </remarks>
-        public static async Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             HttpCompletionOption completionOption,
@@ -426,9 +391,9 @@ namespace System.Net.Http
         {
             if (credentials == null) throw new ArgumentNullException(nameof(credentials));
 
-            var immutableCredentials = await credentials.GetCredentialsAsync();
+            var immutableCredentials = credentials.GetCredentials();
 
-            var response = await self.SendAsync(
+            var response = self.Send(
                 request,
                 completionOption,
                 cancellationToken,
@@ -440,7 +405,7 @@ namespace System.Net.Http
         }
 
         /// <summary>
-        /// Send an Signature Version 4 signed HTTP request as an asynchronous operation.
+        /// Send an Signature Version 4 signed HTTP request as a synchronous operation.
         /// </summary>
         /// <param name="self">
         /// The extension target.
@@ -469,7 +434,7 @@ namespace System.Net.Http
         ///   security credentials, e.g. a role.
         /// </param>
         /// <returns>
-        /// The task object representing the asynchronous operation.
+        /// The response message.
         /// </returns>
         /// <exception cref="ArgumentNullException">
         /// The <paramref name="request"/> is null.
@@ -481,13 +446,7 @@ namespace System.Net.Http
         /// The request failed due to an underlying issue such as network connectivity, DNS
         /// failure, server certificate validation or timeout.
         /// </exception>
-        /// <remarks>
-        /// This operation will not block. Depending on the value of the
-        /// <paramref name="completionOption"/> parameter, the returned <see cref="Task{TResult}"/>
-        /// object will complete as soon as a response is available or the entire response
-        /// including content is read.
-        /// </remarks>
-        public static async Task<HttpResponseMessage> SendAsync(
+        public static HttpResponseMessage Send(
             this HttpClient self,
             HttpRequestMessage request,
             HttpCompletionOption completionOption,
@@ -498,7 +457,7 @@ namespace System.Net.Http
         {
             if (self == null) throw new ArgumentNullException(nameof(self));
 
-            await Signer.SignAsync(
+            var signingTask = Signer.SignAsync(
                 request,
                 self.BaseAddress,
                 self.DefaultRequestHeaders,
@@ -507,9 +466,13 @@ namespace System.Net.Http
                 serviceName,
                 credentials);
 
-            return await self.SendAsync(request, completionOption, cancellationToken);
+            System.Diagnostics.Debug.Assert(signingTask.IsCompletedSuccessfully, "The operation should have completed synchronously.");
+
+            return self.Send(request, completionOption, cancellationToken);
         }
 
         #endregion
     }
 }
+
+#endif

--- a/test/Integration/ApiGateway/Contents/Extensions.cs
+++ b/test/Integration/ApiGateway/Contents/Extensions.cs
@@ -8,7 +8,7 @@ namespace AwsSignatureVersion4.Integration.ApiGateway.Contents
     public static class Extensions
     {
         public static StringContent ToJsonContent(this Type self) =>
-            new StringContent(
+            new(
                 JsonConvert.SerializeObject(Activator.CreateInstance(self)),
                 Encoding.UTF8,
                 "application/json");

--- a/test/Integration/ApiGateway/SendAsyncShould.cs
+++ b/test/Integration/ApiGateway/SendAsyncShould.cs
@@ -272,7 +272,7 @@ namespace AwsSignatureVersion4.Integration.ApiGateway
         public async Task PassTestSuiteGivenUserWithPermissions(params string[] scenarioName)
         {
             // Arrange
-            var request = BuildRequest(scenarioName);
+            var request = BuildRequest(testSuiteContext, Context, scenarioName);
             var iamAuthenticationType = IamAuthenticationType.User;
 
             // Act
@@ -321,7 +321,7 @@ namespace AwsSignatureVersion4.Integration.ApiGateway
         public async Task PassTestSuiteGivenAssumedRole(params string[] scenarioName)
         {
             // Arrange
-            var request = BuildRequest(scenarioName);
+            var request = BuildRequest(testSuiteContext, Context, scenarioName);
             var iamAuthenticationType = IamAuthenticationType.Role;
 
             // Act
@@ -515,14 +515,17 @@ namespace AwsSignatureVersion4.Integration.ApiGateway
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
         }
 
-        private HttpRequestMessage BuildRequest(string[] scenarioName)
+        internal static HttpRequestMessage BuildRequest(
+            TestSuiteContext testSuiteContext,
+            IntegrationTestContext integrationTestContext,
+            string[] scenarioName)
         {
             var request = testSuiteContext.LoadScenario(scenarioName).Request;
 
             // Redirect the request to the AWS API Gateway
             request.RequestUri = request.RequestUri
                 .ToString()
-                .Replace("https://example.amazonaws.com", Context.ApiGatewayUrl)
+                .Replace("https://example.amazonaws.com", integrationTestContext.ApiGatewayUrl)
                 .ToUri();
 
             // The "Host" header is now invalid since we redirected the request to the AWS API

--- a/test/Integration/ApiGateway/SendShould.cs
+++ b/test/Integration/ApiGateway/SendShould.cs
@@ -1,0 +1,536 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using AwsSignatureVersion4.Integration.ApiGateway.Authentication;
+using AwsSignatureVersion4.Private;
+using AwsSignatureVersion4.TestSuite;
+using Shouldly;
+using Xunit;
+
+namespace AwsSignatureVersion4.Integration.ApiGateway
+{
+    public class SendShould : ApiGatewayIntegrationBase, IClassFixture<TestSuiteContext>
+    {
+        private readonly TestSuiteContext testSuiteContext;
+
+        public SendShould(IntegrationTestContext context, TestSuiteContext testSuiteContext)
+            : base(context)
+        {
+            this.testSuiteContext = testSuiteContext;
+        }
+
+        #region Send(HttpRequestMessage, string, string, <credentials>)
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenMutableCredentials(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenImmutableCredentials(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveImmutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        #endregion
+
+        #region Send(HttpRequestMessage, HttpCompletionOption, string, string, <credentials>)
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User)]
+        [InlineData(IamAuthenticationType.Role)]
+        public void SucceedGivenHttpCompletionOptionAndMutableCredentials(IamAuthenticationType iamAuthenticationType)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, Context.ApiGatewayUrl);
+            var completionOption = HttpCompletionOption.ResponseContentRead;
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                completionOption,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User)]
+        [InlineData(IamAuthenticationType.Role)]
+        public void SucceedGivenHttpCompletionOptionAndImmutableCredentials(IamAuthenticationType iamAuthenticationType)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, Context.ApiGatewayUrl);
+            var completionOption = HttpCompletionOption.ResponseContentRead;
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                completionOption,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveImmutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        #endregion
+
+        #region Send(HttpRequestMessage, CancellationToken, string, string, <credentials>)
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenCancellationTokenAndMutableCredentials(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+            var ct = new CancellationToken();
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                ct,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenCancellationTokenAndImmutableCredentials(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+            var ct = new CancellationToken();
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                ct,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveImmutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        #endregion
+
+        #region Send(HttpRequestMessage, HttpCompletionOption, CancellationToken, string, string, <credentials>)
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User)]
+        [InlineData(IamAuthenticationType.Role)]
+        public void SucceedGivenHttpCompletionOptionAndCancellationTokenMutableCredentials(IamAuthenticationType iamAuthenticationType)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, Context.ApiGatewayUrl);
+            var completionOption = HttpCompletionOption.ResponseContentRead;
+            var ct = new CancellationToken();
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                completionOption,
+                ct,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User)]
+        [InlineData(IamAuthenticationType.Role)]
+        public void SucceedGivenHttpCompletionOptionAndCancellationTokenAndImmutableCredentials(IamAuthenticationType iamAuthenticationType)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, Context.ApiGatewayUrl);
+            var completionOption = HttpCompletionOption.ResponseContentRead;
+            var ct = new CancellationToken();
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                completionOption,
+                ct,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveImmutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        #endregion
+
+        [Theory]
+        [InlineData("get-header-key-duplicate")]
+        [InlineData("get-header-value-multiline")]
+        [InlineData("get-header-value-order")]
+        [InlineData("get-header-value-trim")]
+        [InlineData("get-unreserved")]
+        [InlineData("get-utf8")]
+        [InlineData("get-vanilla")]
+        [InlineData("get-vanilla-empty-query-key")]
+        [InlineData("get-vanilla-query")]
+        [InlineData("get-vanilla-query-order-key")]
+        [InlineData("get-vanilla-query-order-key-case")]
+        [InlineData("get-vanilla-query-order-value")]
+        [InlineData("get-vanilla-query-unreserved", Skip = SkipReasons.NotSupportedByApiGateway)]
+        [InlineData("get-vanilla-utf8-query")]
+        [InlineData("normalize-path", "get-relative")]
+        [InlineData("normalize-path", "get-relative-relative")]
+        [InlineData("normalize-path", "get-slash")]
+        [InlineData("normalize-path", "get-slash-dot-slash")]
+        [InlineData("normalize-path", "get-slashes")]
+        [InlineData("normalize-path", "get-slash-pointless-dot")]
+        [InlineData("normalize-path", "get-space")]
+        [InlineData("post-header-key-case")]
+        [InlineData("post-header-key-sort")]
+        [InlineData("post-header-value-case")]
+        [InlineData("post-sts-token", "post-sts-header-after")]
+        [InlineData("post-sts-token", "post-sts-header-before", Skip = SkipReasons.RedundantStsTokenScenario)]
+        [InlineData("post-vanilla")]
+        [InlineData("post-vanilla-empty-query-value")]
+        [InlineData("post-vanilla-query")]
+        [InlineData("post-x-www-form-urlencoded")]
+        [InlineData("post-x-www-form-urlencoded-parameters", Skip = SkipReasons.RedundantContentTypeCharset)]
+        public void PassTestSuiteGivenUserWithPermissions(params string[] scenarioName)
+        {
+            // Arrange
+            var request = BuildRequest(scenarioName);
+            var iamAuthenticationType = IamAuthenticationType.User;
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData("get-header-key-duplicate")]
+        [InlineData("get-header-value-multiline")]
+        [InlineData("get-header-value-order")]
+        [InlineData("get-header-value-trim")]
+        [InlineData("get-unreserved")]
+        [InlineData("get-utf8")]
+        [InlineData("get-vanilla")]
+        [InlineData("get-vanilla-empty-query-key")]
+        [InlineData("get-vanilla-query")]
+        [InlineData("get-vanilla-query-order-key")]
+        [InlineData("get-vanilla-query-order-key-case")]
+        [InlineData("get-vanilla-query-order-value")]
+        [InlineData("get-vanilla-query-unreserved", Skip = SkipReasons.NotSupportedByApiGateway)]
+        [InlineData("get-vanilla-utf8-query")]
+        [InlineData("normalize-path", "get-relative")]
+        [InlineData("normalize-path", "get-relative-relative")]
+        [InlineData("normalize-path", "get-slash")]
+        [InlineData("normalize-path", "get-slash-dot-slash")]
+        [InlineData("normalize-path", "get-slashes")]
+        [InlineData("normalize-path", "get-slash-pointless-dot")]
+        [InlineData("normalize-path", "get-space")]
+        [InlineData("post-header-key-case")]
+        [InlineData("post-header-key-sort")]
+        [InlineData("post-header-value-case")]
+        [InlineData("post-sts-token", "post-sts-header-after")]
+        [InlineData("post-sts-token", "post-sts-header-before", Skip = SkipReasons.RedundantStsTokenScenario)]
+        [InlineData("post-vanilla")]
+        [InlineData("post-vanilla-empty-query-value")]
+        [InlineData("post-vanilla-query")]
+        [InlineData("post-x-www-form-urlencoded")]
+        [InlineData("post-x-www-form-urlencoded-parameters", Skip = SkipReasons.RedundantContentTypeCharset)]
+        public void PassTestSuiteGivenAssumedRole(params string[] scenarioName)
+        {
+            // Arrange
+            var request = BuildRequest(scenarioName);
+            var iamAuthenticationType = IamAuthenticationType.Role;
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenHeaderWithDuplicateValues(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+            request.AddHeaders("My-Header1", new[] { "value2", "value2" });
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenHeaderWithUnorderedValues(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+            request.AddHeaders("My-Header1", new[] { "value4", "value1", "value3", "value2" });
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenHeaderWithWhitespaceCharacters(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var request = new HttpRequestMessage(new HttpMethod(method), Context.ApiGatewayUrl);
+            request.AddHeaders("My-Header1", new[] { "value1", "a   b   c" });
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenQuery(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var uriBuilder = new UriBuilder(Context.ApiGatewayUrl)
+            {
+                Query = "Param1=value1"
+            };
+
+            var request = new HttpRequestMessage(new HttpMethod(method), uriBuilder.Uri);
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenOrderedQuery(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var uriBuilder = new UriBuilder(Context.ApiGatewayUrl)
+            {
+                Query = "Param1=Value1&Param1=value2"
+            };
+
+            var request = new HttpRequestMessage(new HttpMethod(method), uriBuilder.Uri);
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        [Theory]
+        [InlineData(IamAuthenticationType.User, "GET")]
+        [InlineData(IamAuthenticationType.User, "POST")]
+        [InlineData(IamAuthenticationType.User, "PUT")]
+        [InlineData(IamAuthenticationType.User, "DELETE")]
+        [InlineData(IamAuthenticationType.Role, "GET")]
+        [InlineData(IamAuthenticationType.Role, "POST")]
+        [InlineData(IamAuthenticationType.Role, "PUT")]
+        [InlineData(IamAuthenticationType.Role, "DELETE")]
+        public void SucceedGivenUnorderedQuery(
+            IamAuthenticationType iamAuthenticationType,
+            string method)
+        {
+            // Arrange
+            var uriBuilder = new UriBuilder(Context.ApiGatewayUrl)
+            {
+                Query = "Param1=value2&Param1=Value1"
+            };
+
+            var request = new HttpRequestMessage(new HttpMethod(method), uriBuilder.Uri);
+
+            // Act
+            var response = HttpClient.Send(
+                request,
+                Context.RegionName,
+                Context.ServiceName,
+                ResolveMutableCredentials(iamAuthenticationType));
+
+            // Assert
+            response.StatusCode.ShouldBe(HttpStatusCode.OK);
+        }
+
+        private HttpRequestMessage BuildRequest(string[] scenarioName)
+        {
+            var request = testSuiteContext.LoadScenario(scenarioName).Request;
+
+            // Redirect the request to the AWS API Gateway
+            request.RequestUri = request.RequestUri
+                .ToString()
+                .Replace("https://example.amazonaws.com", Context.ApiGatewayUrl)
+                .ToUri();
+
+            // The "Host" header is now invalid since we redirected the request to the AWS API
+            // Gateway. Lets remove the header and have the signature implementation re-add it
+            // correctly.
+            request.Headers.Remove("Host");
+
+            return request;
+        }
+    }
+}

--- a/test/Integration/ApiGateway/SendShould.cs
+++ b/test/Integration/ApiGateway/SendShould.cs
@@ -271,7 +271,7 @@ namespace AwsSignatureVersion4.Integration.ApiGateway
         public void PassTestSuiteGivenUserWithPermissions(params string[] scenarioName)
         {
             // Arrange
-            var request = BuildRequest(scenarioName);
+            var request = SendAsyncShould.BuildRequest(testSuiteContext, Context, scenarioName);
             var iamAuthenticationType = IamAuthenticationType.User;
 
             // Act
@@ -320,7 +320,7 @@ namespace AwsSignatureVersion4.Integration.ApiGateway
         public void PassTestSuiteGivenAssumedRole(params string[] scenarioName)
         {
             // Arrange
-            var request = BuildRequest(scenarioName);
+            var request = SendAsyncShould.BuildRequest(testSuiteContext, Context, scenarioName);
             var iamAuthenticationType = IamAuthenticationType.Role;
 
             // Act
@@ -512,24 +512,6 @@ namespace AwsSignatureVersion4.Integration.ApiGateway
 
             // Assert
             response.StatusCode.ShouldBe(HttpStatusCode.OK);
-        }
-
-        private HttpRequestMessage BuildRequest(string[] scenarioName)
-        {
-            var request = testSuiteContext.LoadScenario(scenarioName).Request;
-
-            // Redirect the request to the AWS API Gateway
-            request.RequestUri = request.RequestUri
-                .ToString()
-                .Replace("https://example.amazonaws.com", Context.ApiGatewayUrl)
-                .ToUri();
-
-            // The "Host" header is now invalid since we redirected the request to the AWS API
-            // Gateway. Lets remove the header and have the signature implementation re-add it
-            // correctly.
-            request.Headers.Remove("Host");
-
-            return request;
         }
     }
 }

--- a/test/Integration/ApiGateway/SendShould.cs
+++ b/test/Integration/ApiGateway/SendShould.cs
@@ -2,7 +2,6 @@ using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
-using System.Threading.Tasks;
 using AwsSignatureVersion4.Integration.ApiGateway.Authentication;
 using AwsSignatureVersion4.Private;
 using AwsSignatureVersion4.TestSuite;

--- a/test/TestSuite/Serialization/StringContentSerializer.cs
+++ b/test/TestSuite/Serialization/StringContentSerializer.cs
@@ -11,6 +11,8 @@ namespace AwsSignatureVersion4.TestSuite.Serialization
 
         protected string FilePath { get; }
 
-        public string Deserialize() => File.ReadAllText(FilePath);
+        public string Deserialize() => File.ReadAllText(FilePath)
+            // Make sure we compensate for line endings on Windows
+            .Replace("\r\n", "\n");
     }
 }

--- a/test/TestSuite/TestSuiteContext.cs
+++ b/test/TestSuite/TestSuiteContext.cs
@@ -16,7 +16,7 @@ namespace AwsSignatureVersion4.TestSuite
 
         public string ServiceName { get; } = "service";
 
-        public DateTime UtcNow { get; } = new DateTime(
+        public DateTime UtcNow { get; } = new(
             2015,
             8,
             30,
@@ -25,7 +25,7 @@ namespace AwsSignatureVersion4.TestSuite
             00,
             DateTimeKind.Utc);
 
-        public ImmutableCredentials Credentials { get; } = new ImmutableCredentials(
+        public ImmutableCredentials Credentials { get; } = new(
             "AKIDEXAMPLE",
             "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY",
             null);

--- a/test/Unit/AwsSignatureHandlerShould.cs
+++ b/test/Unit/AwsSignatureHandlerShould.cs
@@ -157,7 +157,7 @@ namespace AwsSignatureVersion4.Unit
         #endregion
 
         private static AwsSignatureHandlerSettings CreateSettings(string serviceName) =>
-            new AwsSignatureHandlerSettings(
+            new(
                 "us-east-1",
                 serviceName,
                 new ImmutableCredentials(

--- a/test/Unit/AwsSignatureHandlerShould.cs
+++ b/test/Unit/AwsSignatureHandlerShould.cs
@@ -20,10 +20,12 @@ namespace AwsSignatureVersion4.Unit
             sinkHandler = new SinkHandler();
         }
 
+        #region Set headers
+
         [Theory]
         [InlineData("execute-api")]
         [InlineData("s3")]
-        public async Task SetHeaders(string serviceName)
+        public async Task SetHeadersAsync(string serviceName)
         {
             // Arrange
             var handler = new AwsSignatureHandler(CreateSettings(serviceName))
@@ -54,7 +56,7 @@ namespace AwsSignatureVersion4.Unit
         [Theory]
         [InlineData("execute-api")]
         [InlineData("s3")]
-        public void SetHeadersGivenAsyncFalse(string serviceName)
+        public void SetHeaders(string serviceName)
         {
             // Arrange
             var handler = new AwsSignatureHandler(CreateSettings(serviceName))
@@ -82,10 +84,14 @@ namespace AwsSignatureVersion4.Unit
             }
         }
 
+        #endregion
+
+        #region Reset headers
+
         [Theory]
         [InlineData("execute-api")]
         [InlineData("s3")]
-        public async Task ResetHeaders(string serviceName)
+        public async Task ResetHeadersAsync(string serviceName)
         {
             var handler = new AwsSignatureHandler(CreateSettings(serviceName))
             {
@@ -118,7 +124,7 @@ namespace AwsSignatureVersion4.Unit
         [Theory]
         [InlineData("execute-api")]
         [InlineData("s3")]
-        public void ResetHeadersGivenAsyncFalse(string serviceName)
+        public void ResetHeaders(string serviceName)
         {
             var handler = new AwsSignatureHandler(CreateSettings(serviceName))
             {
@@ -147,6 +153,8 @@ namespace AwsSignatureVersion4.Unit
                 }
             }
         }
+
+        #endregion
 
         private static AwsSignatureHandlerSettings CreateSettings(string serviceName) =>
             new AwsSignatureHandlerSettings(
@@ -179,21 +187,21 @@ namespace AwsSignatureVersion4.Unit
         {
             public HttpRequestMessage Request { get; private set; }
 
-            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override Task<HttpResponseMessage> SendAsync(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
             {
-                Request = request;
-
-                return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+                return Task.FromResult(Send(request, cancellationToken));
             }
 
-            protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+            protected override HttpResponseMessage Send(
+                HttpRequestMessage request,
+                CancellationToken cancellationToken)
             {
                 Request = request;
 
-                return SendAsync(request, cancellationToken).GetAwaiter().GetResult();
+                return new HttpResponseMessage(HttpStatusCode.OK);
             }
         }
-
-
     }
 }

--- a/test/Unit/AwsSignatureHandlerShould.cs
+++ b/test/Unit/AwsSignatureHandlerShould.cs
@@ -14,7 +14,7 @@ namespace AwsSignatureVersion4.Unit
     public class AwsSignatureHandlerShould
     {
         private readonly SinkHandler sinkHandler;
-        
+
         public AwsSignatureHandlerShould()
         {
             sinkHandler = new SinkHandler();
@@ -98,7 +98,7 @@ namespace AwsSignatureVersion4.Unit
                 new Uri("https://example.amazonaws.com/resource/path"));
 
             var ct = new CancellationToken();
-            
+
             for (var i = 0; i < 2; i++)
             {
                 // Act
@@ -186,6 +186,13 @@ namespace AwsSignatureVersion4.Unit
                 Request = request;
 
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+
+            protected override HttpResponseMessage Send(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                Request = request;
+
+                return base.Send(request, cancellationToken);
             }
         }
 

--- a/test/Unit/Private/ContentHashShould.cs
+++ b/test/Unit/Private/ContentHashShould.cs
@@ -11,50 +11,77 @@ namespace AwsSignatureVersion4.Unit.Private
         private const string EmptyContentHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
         [Fact]
-        public async Task SupportNullContent()
+        public async Task SupportNullContentAsync()
         {
             // Act
-            // ReSharper disable once MethodHasAsyncOverload
-            var actual1 = ContentHash.Calculate(null);
-            var actual2 = await ContentHash.CalculateAsync(null);
+            var actual = await ContentHash.CalculateAsync(null);
             
             // Assert
-            actual1.ShouldBe(EmptyContentHash);
-            actual2.ShouldBe(EmptyContentHash);
+            actual.ShouldBe(EmptyContentHash);
         }
 
         [Fact]
-        public async Task SupportEmptyStringContent()
+        public void SupportNullContent()
+        {
+            // Act
+            var actual = ContentHash.Calculate(null);
+
+            // Assert
+            actual.ShouldBe(EmptyContentHash);
+        }
+
+        [Fact]
+        public async Task SupportEmptyStringContentAsync()
         {
             // Arrange
             HttpContent content = new StringContent(string.Empty);
 
             // Act
-            // ReSharper disable once MethodHasAsyncOverload
-            var actual1 = ContentHash.Calculate(content);
-            var actual2 = await ContentHash.CalculateAsync(content);
+            var actual = await ContentHash.CalculateAsync(content);
 
             // Assert
-            actual1.ShouldBe(EmptyContentHash);
-            actual2.ShouldBe(EmptyContentHash);
+            actual.ShouldBe(EmptyContentHash);
         }
 
         [Fact]
-        public async Task CalculateValidHash()
+        public void SupportEmptyStringContent()
+        {
+            // Arrange
+            HttpContent content = new StringContent(string.Empty);
+
+            // Act
+            var actual = ContentHash.Calculate(content);
+            
+            // Assert
+            actual.ShouldBe(EmptyContentHash);
+        }
+
+        [Fact]
+        public async Task CalculateValidHashAsync()
         {
             // Arrange
             HttpContent content = new StringContent("foo");
 
             // Act
-            // ReSharper disable once MethodHasAsyncOverload
-            var actual1 = ContentHash.Calculate(content);
-            var actual2 = await ContentHash.CalculateAsync(content);
+            var actual = await ContentHash.CalculateAsync(content);
 
             // Assert
-            actual1.Length.ShouldBe(64);
-            actual2.Length.ShouldBe(64);
-            IsHex(actual1).ShouldBeTrue();
-            IsHex(actual2).ShouldBeTrue();
+            actual.Length.ShouldBe(64);
+            IsHex(actual).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void CalculateValidHash()
+        {
+            // Arrange
+            HttpContent content = new StringContent("foo");
+
+            // Act
+            var actual = ContentHash.Calculate(content);
+            
+            // Assert
+            actual.Length.ShouldBe(64);
+            IsHex(actual).ShouldBeTrue();
         }
 
         private static bool IsHex(string value)

--- a/test/Unit/Private/ContentHashShould.cs
+++ b/test/Unit/Private/ContentHashShould.cs
@@ -10,6 +10,8 @@ namespace AwsSignatureVersion4.Unit.Private
     {
         private const string EmptyContentHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
 
+        #region Support null content
+
         [Fact]
         public async Task SupportNullContentAsync()
         {
@@ -29,6 +31,10 @@ namespace AwsSignatureVersion4.Unit.Private
             // Assert
             actual.ShouldBe(EmptyContentHash);
         }
+
+        #endregion
+
+        #region Support empty string content
 
         [Fact]
         public async Task SupportEmptyStringContentAsync()
@@ -55,6 +61,10 @@ namespace AwsSignatureVersion4.Unit.Private
             // Assert
             actual.ShouldBe(EmptyContentHash);
         }
+
+        #endregion
+
+        #region Calculate valid hash
 
         [Fact]
         public async Task CalculateValidHashAsync()
@@ -83,6 +93,8 @@ namespace AwsSignatureVersion4.Unit.Private
             actual.Length.ShouldBe(64);
             IsHex(actual).ShouldBeTrue();
         }
+
+        #endregion
 
         private static bool IsHex(string value)
         {

--- a/test/Unit/Private/ContentHashShould.cs
+++ b/test/Unit/Private/ContentHashShould.cs
@@ -14,23 +14,29 @@ namespace AwsSignatureVersion4.Unit.Private
         public async Task SupportNullContent()
         {
             // Act
-            var actual = await ContentHash.CalculateAsync(null);
-
+            // ReSharper disable once MethodHasAsyncOverload
+            var actual1 = ContentHash.Calculate(null);
+            var actual2 = await ContentHash.CalculateAsync(null);
+            
             // Assert
-            actual.ShouldBe(EmptyContentHash);
+            actual1.ShouldBe(EmptyContentHash);
+            actual2.ShouldBe(EmptyContentHash);
         }
 
         [Fact]
         public async Task SupportEmptyStringContent()
         {
             // Arrange
-            HttpContent content = new  StringContent(string.Empty);
+            HttpContent content = new StringContent(string.Empty);
 
             // Act
-            var actual = await ContentHash.CalculateAsync(content);
+            // ReSharper disable once MethodHasAsyncOverload
+            var actual1 = ContentHash.Calculate(content);
+            var actual2 = await ContentHash.CalculateAsync(content);
 
             // Assert
-            actual.ShouldBe(EmptyContentHash);
+            actual1.ShouldBe(EmptyContentHash);
+            actual2.ShouldBe(EmptyContentHash);
         }
 
         [Fact]
@@ -40,11 +46,15 @@ namespace AwsSignatureVersion4.Unit.Private
             HttpContent content = new StringContent("foo");
 
             // Act
-            var actual = await ContentHash.CalculateAsync(content);
+            // ReSharper disable once MethodHasAsyncOverload
+            var actual1 = ContentHash.Calculate(content);
+            var actual2 = await ContentHash.CalculateAsync(content);
 
             // Assert
-            actual.Length.ShouldBe(64);
-            IsHex(actual).ShouldBeTrue();
+            actual1.Length.ShouldBe(64);
+            actual2.Length.ShouldBe(64);
+            IsHex(actual1).ShouldBeTrue();
+            IsHex(actual2).ShouldBeTrue();
         }
 
         private static bool IsHex(string value)

--- a/test/Unit/Private/SignerGivenS3Should.cs
+++ b/test/Unit/Private/SignerGivenS3Should.cs
@@ -22,8 +22,10 @@ namespace AwsSignatureVersion4.Unit.Private
             context.AdjustHeaderValueSeparator();
         }
 
+        #region Add X-Amz-Content-SHA256 header
+
         [Fact]
-        public async Task AddXAmzContentHeader()
+        public async Task AddXAmzContentHeaderAsync()
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
@@ -41,6 +43,28 @@ namespace AwsSignatureVersion4.Unit.Private
             // Assert
             request.Headers.Contains("X-Amz-Content-SHA256").ShouldBeTrue();
         }
+
+        [Fact]
+        public void AddXAmzContentHeader()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
+
+            // Act
+            Signer.Sign(
+                request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                "s3",
+                context.Credentials);
+
+            // Assert
+            request.Headers.Contains("X-Amz-Content-SHA256").ShouldBeTrue();
+        }
+
+        #endregion
 
         public void Dispose()
         {

--- a/test/Unit/Private/SignerShould.cs
+++ b/test/Unit/Private/SignerShould.cs
@@ -25,6 +25,8 @@ namespace AwsSignatureVersion4.Unit.Private
             context.AdjustHeaderValueSeparator();
         }
 
+        #region Pass test suite
+
         [Theory]
         [InlineData("get-header-key-duplicate")]
         [InlineData("get-header-value-multiline")]
@@ -57,7 +59,7 @@ namespace AwsSignatureVersion4.Unit.Private
         [InlineData("post-vanilla-query")]
         [InlineData("post-x-www-form-urlencoded", Skip = SkipReasons.RedundantContentTypeCharset)]
         [InlineData("post-x-www-form-urlencoded-parameters", Skip = SkipReasons.RedundantContentTypeCharset)]
-        public async Task PassTestSuite(params string[] scenarioName)
+        public async Task PassTestSuiteAsync(params string[] scenarioName)
         {
             // Arrange
             var scenario = context.LoadScenario(scenarioName);
@@ -81,28 +83,63 @@ namespace AwsSignatureVersion4.Unit.Private
         }
 
         [Theory]
+        [InlineData("get-header-key-duplicate")]
+        [InlineData("get-header-value-multiline")]
+        [InlineData("get-header-value-order")]
+        [InlineData("get-header-value-trim")]
+        [InlineData("get-unreserved")]
+        [InlineData("get-utf8", Skip = SkipReasons.PlausibleCanonicalUriTestSuiteError)]
+        [InlineData("get-vanilla")]
+        [InlineData("get-vanilla-empty-query-key")]
+        [InlineData("get-vanilla-query")]
+        [InlineData("get-vanilla-query-order-key")]
+        [InlineData("get-vanilla-query-order-key-case")]
+        [InlineData("get-vanilla-query-order-value")]
+        [InlineData("get-vanilla-query-unreserved")]
+        [InlineData("get-vanilla-utf8-query")]
+        [InlineData("normalize-path", "get-relative")]
+        [InlineData("normalize-path", "get-relative-relative")]
+        [InlineData("normalize-path", "get-slash")]
+        [InlineData("normalize-path", "get-slash-dot-slash")]
+        [InlineData("normalize-path", "get-slashes")]
+        [InlineData("normalize-path", "get-slash-pointless-dot")]
+        [InlineData("normalize-path", "get-space", Skip = SkipReasons.PlausibleCanonicalUriTestSuiteError)]
+        [InlineData("post-header-key-case")]
+        [InlineData("post-header-key-sort")]
+        [InlineData("post-header-value-case")]
+        [InlineData("post-sts-token", "post-sts-header-after")]
+        [InlineData("post-sts-token", "post-sts-header-before")]
         [InlineData("post-vanilla")]
-        public void CompleteSynchronouslyGivenAsyncFalse(params string[] scenarioName)
+        [InlineData("post-vanilla-empty-query-value")]
+        [InlineData("post-vanilla-query")]
+        [InlineData("post-x-www-form-urlencoded", Skip = SkipReasons.RedundantContentTypeCharset)]
+        [InlineData("post-x-www-form-urlencoded-parameters", Skip = SkipReasons.RedundantContentTypeCharset)]
+        public void PassTestSuite(params string[] scenarioName)
         {
             // Arrange
             var scenario = context.LoadScenario(scenarioName);
 
             // Act
-            var signingTask = Signer.SignAsync(
+            var actual = Signer.Sign(
                 scenario.Request,
                 httpClient.BaseAddress,
                 httpClient.DefaultRequestHeaders,
                 context.UtcNow,
                 context.RegionName,
                 context.ServiceName,
-                context.Credentials,
-                async: false);
+                context.Credentials);
 
             // Assert
-            Assert.Equal(TaskStatus.RanToCompletion, signingTask.Status);
+            actual.CanonicalRequest.ShouldBe(scenario.ExpectedCanonicalRequest);
+            actual.StringToSign.ShouldBe(scenario.ExpectedStringToSign);
+            actual.AuthorizationHeader.ShouldBe(scenario.ExpectedAuthorizationHeader);
 
             scenario.Request.Headers.GetValues("Authorization").Single().ShouldBe(scenario.ExpectedAuthorizationHeader);
         }
+
+        #endregion
+
+        #region Respect base address
 
         [Theory]
         [InlineData("https://github.com/FantasticFiasco", null, "https://github.com/FantasticFiasco")]
@@ -110,7 +147,7 @@ namespace AwsSignatureVersion4.Unit.Private
         [InlineData("https://github.com", "/FantasticFiasco", "https://github.com/FantasticFiasco")]
         [InlineData("https://github.com/", "/FantasticFiasco", "https://github.com/FantasticFiasco")]
         [InlineData(null, "https://github.com/FantasticFiasco", "https://github.com/FantasticFiasco")]
-        public async Task RespectBaseAddress(string baseAddress, string requestUri, string expectedRequestUri)
+        public async Task RespectBaseAddressAsync(string baseAddress, string requestUri, string expectedRequestUri)
         {
             // Arrange
             httpClient.BaseAddress = baseAddress != null
@@ -133,11 +170,43 @@ namespace AwsSignatureVersion4.Unit.Private
             request.RequestUri.ShouldBe(new Uri(expectedRequestUri));
         }
 
-        /// <summary>
-        /// Only requests to S3 should add the "X-Amz-Content-SHA256" header.
-        /// </summary>
+        [Theory]
+        [InlineData("https://github.com/FantasticFiasco", null, "https://github.com/FantasticFiasco")]
+        [InlineData("https://github.com/", "FantasticFiasco", "https://github.com/FantasticFiasco")]
+        [InlineData("https://github.com", "/FantasticFiasco", "https://github.com/FantasticFiasco")]
+        [InlineData("https://github.com/", "/FantasticFiasco", "https://github.com/FantasticFiasco")]
+        [InlineData(null, "https://github.com/FantasticFiasco", "https://github.com/FantasticFiasco")]
+        public void RespectBaseAddress(string baseAddress, string requestUri, string expectedRequestUri)
+        {
+            // Arrange
+            httpClient.BaseAddress = baseAddress != null
+                ? new Uri(baseAddress)
+                : null;
+
+            var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+            // Act
+            Signer.Sign(
+                request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                context.ServiceName,
+                context.Credentials);
+
+            // Assert
+            request.RequestUri.ShouldBe(new Uri(expectedRequestUri));
+        }
+
+        #endregion
+
+        #region Not add X-Amz-Content-SHA256 content header
+
+        // Only requests to S3 should add the "X-Amz-Content-SHA256" header
+        
         [Fact]
-        public async Task NotAddXAmzContentHeader()
+        public async Task NotAddXAmzContentHeaderAsync()
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
@@ -157,7 +226,31 @@ namespace AwsSignatureVersion4.Unit.Private
         }
 
         [Fact]
-        public async Task ThrowArgumentExceptionGivenXAmzDateHeader()
+        public void NotAddXAmzContentHeader()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
+
+            // Act
+            Signer.Sign(
+                request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                context.ServiceName,
+                context.Credentials);
+
+            // Assert
+            request.Headers.Contains("X-Amz-Content-SHA256").ShouldBeFalse();
+        }
+
+        #endregion
+
+        #region Throw ArgumentException given X-Amz-Date header
+
+        [Fact]
+        public async Task ThrowArgumentExceptionGivenXAmzDateHeaderAsync()
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
@@ -178,7 +271,32 @@ namespace AwsSignatureVersion4.Unit.Private
         }
 
         [Fact]
-        public async Task ThrowArgumentExceptionGivenAuthorizationHeader()
+        public void ThrowArgumentExceptionGivenXAmzDateHeader()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
+            request.AddHeader(HeaderKeys.XAmzDateHeader, "some value");
+
+            // Act
+            Action actual = () => Signer.Sign(
+                request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                context.ServiceName,
+                context.Credentials);
+
+            // Assert
+            actual.ShouldThrow<ArgumentException>();
+        }
+
+        #endregion
+
+        #region Throw ArgumentException given Authorization header
+
+        [Fact]
+        public async Task ThrowArgumentExceptionGivenAuthorizationHeaderAsync()
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
@@ -199,7 +317,32 @@ namespace AwsSignatureVersion4.Unit.Private
         }
 
         [Fact]
-        public async Task ThrowArgumentExceptionGivenAuthorizationHeaderAddedByName()
+        public void ThrowArgumentExceptionGivenAuthorizationHeader()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Some-Schema");
+
+            // Act
+            Action actual = () => Signer.Sign(
+                request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                context.ServiceName,
+                context.Credentials);
+
+            // Assert
+            actual.ShouldThrow<ArgumentException>();
+        }
+
+        #endregion
+
+        #region Throw ArgumentException given Authorization header added by name
+
+        [Fact]
+        public async Task ThrowArgumentExceptionGivenAuthorizationHeaderAddedByNameAsync()
         {
             // Arrange
             var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
@@ -218,6 +361,29 @@ namespace AwsSignatureVersion4.Unit.Private
             // Assert
             await actual.ShouldThrowAsync<ArgumentException>();
         }
+
+        [Fact]
+        public void ThrowArgumentExceptionGivenAuthorizationHeaderAddedByName()
+        {
+            // Arrange
+            var request = new HttpRequestMessage(HttpMethod.Get, "https://github.com/FantasticFiasco");
+            request.AddHeader(HeaderKeys.AuthorizationHeader, "some value");
+
+            // Act
+            Action actual = () => Signer.Sign(
+                request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                context.ServiceName,
+                context.Credentials);
+
+            // Assert
+            actual.ShouldThrow<ArgumentException>();
+        }
+
+        #endregion
 
         public void Dispose()
         {

--- a/test/Unit/Private/SignerShould.cs
+++ b/test/Unit/Private/SignerShould.cs
@@ -81,6 +81,30 @@ namespace AwsSignatureVersion4.Unit.Private
         }
 
         [Theory]
+        [InlineData("post-vanilla")]
+        public void CompleteSynchronouslyGivenAsyncFalse(params string[] scenarioName)
+        {
+            // Arrange
+            var scenario = context.LoadScenario(scenarioName);
+
+            // Act
+            var signingTask = Signer.SignAsync(
+                scenario.Request,
+                httpClient.BaseAddress,
+                httpClient.DefaultRequestHeaders,
+                context.UtcNow,
+                context.RegionName,
+                context.ServiceName,
+                context.Credentials,
+                async: false);
+
+            // Assert
+            Assert.Equal(TaskStatus.RanToCompletion, signingTask.Status);
+
+            scenario.Request.Headers.GetValues("Authorization").Single().ShouldBe(scenario.ExpectedAuthorizationHeader);
+        }
+
+        [Theory]
         [InlineData("https://github.com/FantasticFiasco", null, "https://github.com/FantasticFiasco")]
         [InlineData("https://github.com/", "FantasticFiasco", "https://github.com/FantasticFiasco")]
         [InlineData("https://github.com", "/FantasticFiasco", "https://github.com/FantasticFiasco")]


### PR DESCRIPTION
fix: Synchronous HttpClient.Send().

AwsSignatureHandler now overrides the synchronous Send() method in .NET 5.

Closes #478.

_I did not have time to conform to the contribution guidelines to the letter. Feel free to use this PR as you see fit. If you prefer to reject it and copy relevant changes to your own PR, I'm all for it._

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

# Checklist

- [ ] I have squashed my commits into a single one with a message that aligns with the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
