### PR TITLE
Add Dev Container support to the infrastructure code

### DIFF
--- a/infrastructure/.devcontainer/Dockerfile
+++ b/infrastructure/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye

--- a/infrastructure/.devcontainer/devcontainer.json
+++ b/infrastructure/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+  "name": "Node.js",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers-contrib/features/aws-cdk:2": {}
+  },
+  "postCreateCommand": "npm ci",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint", // ESLint
+        "editorconfig.editorconfig", // EditorConfig for VS Code
+        "esbenp.prettier-vscode", // Prettier - Code formatter
+        "streetsidesoftware.code-spell-checker" // Code Spell Checker
+      ]
+    }
+  }
+}

--- a/infrastructure/.vscode/extensions.json
+++ b/infrastructure/.vscode/extensions.json
@@ -1,8 +1,0 @@
-{
-  "recommendations": [
-    "dbaeumer.vscode-eslint",
-    "editorconfig.editorconfig",
-    "esbenp.prettier-vscode",
-    "streetsidesoftware.code-spell-checker"
-  ]
-}


### PR DESCRIPTION
# Description

Let's use a Dev Container for the infrastructure project instead of having to install the dependencies on the local computer.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation

