### PR TITLE
Retry network requests in tests

### DIFF
--- a/test/AwsSignatureVersion4.Test.csproj
+++ b/test/AwsSignatureVersion4.Test.csproj
@@ -16,8 +16,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjction" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/test/AwsSignatureVersion4.Test.csproj
+++ b/test/AwsSignatureVersion4.Test.csproj
@@ -16,7 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjction" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />

--- a/test/Integration/IntegrationBase.cs
+++ b/test/Integration/IntegrationBase.cs
@@ -24,11 +24,19 @@ namespace AwsSignatureVersion4.Integration
                 TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(10)
             };
 
+
+
             HttpClient = new HttpClient(
                 new PolicyHttpMessageHandler(
                     HttpPolicyExtensions
                         .HandleTransientHttpError()
-                        .WaitAndRetryAsync(sleepDurations)));
+                        .WaitAndRetryAsync(sleepDurations))
+                {
+                    InnerHandler = new SocketsHttpHandler
+                    {
+                        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+                    }
+                });
 
             serviceCollection = new ServiceCollection();
             serviceCollection


### PR DESCRIPTION
# Description

To improve the resilience of tests, and protect against temporary network failures, lets retry the requests to AWS before considering the test be become a failure.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
