### PR TITLE
Remove .NET 5 conditional statements

### DIFF
--- a/src/AwsSignatureHandler.cs
+++ b/src/AwsSignatureHandler.cs
@@ -60,8 +60,6 @@ namespace AwsSignatureVersion4
             return await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
         }
 
-#if NET5_0_OR_GREATER
-
         /// <inheritdoc />
         protected override HttpResponseMessage Send(
             HttpRequestMessage request,
@@ -82,8 +80,6 @@ namespace AwsSignatureVersion4
 
             return base.Send(request, cancellationToken);
         }
-
-#endif
 
         /// <summary>
         /// Given the idempotent nature of message handlers, lets remove request headers that

--- a/src/GetStringAsyncExtensions.cs
+++ b/src/GetStringAsyncExtensions.cs
@@ -467,11 +467,7 @@ namespace System.Net.Http
                 return string.Empty;
             }
 
-#if NET5_0_OR_GREATER
             return await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
-#else
-            return await content.ReadAsStringAsync().ConfigureAwait(false);
-#endif
         }
 
         #endregion

--- a/src/Private/ContentHash.cs
+++ b/src/Private/ContentHash.cs
@@ -38,8 +38,6 @@ namespace AwsSignatureVersion4.Private
             return AWSSDKUtils.ToHex(hash, true);
         }
 
-#if NET5_0_OR_GREATER
-
         /// <remarks>This method has a asynchronous alternative.</remarks>
         public static string Calculate(HttpContent? content)
         {
@@ -66,7 +64,5 @@ namespace AwsSignatureVersion4.Private
 
             return AWSSDKUtils.ToHex(hash, true);
         }
-
-#endif
     }
 }

--- a/src/Private/Signer.cs
+++ b/src/Private/Signer.cs
@@ -54,8 +54,6 @@ namespace AwsSignatureVersion4.Private
             return new Result(canonicalRequest, stringToSign, authorizationHeader);
         }
 
-#if NET5_0_OR_GREATER
-
         /// <remarks>This method has a asynchronous alternative.</remarks>
         public static Result Sign(
             HttpRequestMessage request,
@@ -100,8 +98,6 @@ namespace AwsSignatureVersion4.Private
 
             return new Result(canonicalRequest, stringToSign, authorizationHeader);
         }
-
-#endif
 
         private static void ValidateArguments(
             HttpRequestMessage request,

--- a/src/SendExtensions.cs
+++ b/src/SendExtensions.cs
@@ -1,6 +1,4 @@
-﻿#if NET5_0_OR_GREATER
-
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 using Amazon.Runtime;
 using AwsSignatureVersion4.Private;
@@ -521,5 +519,3 @@ namespace System.Net.Http
         #endregion
     }
 }
-
-#endif


### PR DESCRIPTION
# Description

The following change is removing the .NET 5 conditional statements from the source code, since the .NET version no longer is supported.

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
