### PR TITLE
Allow AwsSignatureHandler to defer credential resolution to request time

### DIFF
--- a/src/AwsSignatureHandler.cs
+++ b/src/AwsSignatureHandler.cs
@@ -1,8 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.Runtime;
+using Amazon.Runtime.Credentials;
 using Amazon.Util;
 using AwsSignatureVersion4.Private;
 
@@ -44,7 +46,7 @@ namespace AwsSignatureVersion4
         {
             RemoveHeaders(request);
 
-            var immutableCredentials = await settings.Credentials.GetCredentialsAsync().ConfigureAwait(false);
+            var immutableCredentials = await GetImmutableCredentialsAsync().ConfigureAwait(false);
 
             await Signer
                 .SignAsync(
@@ -69,7 +71,7 @@ namespace AwsSignatureVersion4
         {
             RemoveHeaders(request);
 
-            var immutableCredentials = settings.Credentials.GetCredentials();
+            var immutableCredentials = GetImmutableCredentials();
 
             Signer.Sign(
                 request,
@@ -81,6 +83,37 @@ namespace AwsSignatureVersion4
                 immutableCredentials);
 
             return base.Send(request, cancellationToken);
+        }
+
+#endif
+
+        /// <summary>
+        /// Resolves the credentials to sign the request with. When <see cref="AwsSignatureHandlerSettings.Credentials"/>
+        /// is null, falls back to the default AWS credential search order, resolved just before
+        /// signing rather than up front. <see cref="DefaultAWSCredentialsIdentityResolver"/>
+        /// caches the credentials it resolves, and only re-resolves them when the environment or
+        /// the credential/config files backing them change, so calling it on every request is
+        /// cheap.
+        /// </summary>
+        private async Task<ImmutableCredentials> GetImmutableCredentialsAsync()
+        {
+            var credentials = settings.Credentials ?? await DefaultAWSCredentialsIdentityResolver
+                .GetCredentialsAsync()
+                .ConfigureAwait(false);
+
+            return await credentials.GetCredentialsAsync().ConfigureAwait(false);
+        }
+
+#if NET5_0_OR_GREATER
+
+        /// <summary>
+        /// Synchronous counterpart to <see cref="GetImmutableCredentialsAsync"/>.
+        /// </summary>
+        private ImmutableCredentials GetImmutableCredentials()
+        {
+            var credentials = settings.Credentials ?? DefaultAWSCredentialsIdentityResolver.GetCredentials();
+
+            return credentials.GetCredentials();
         }
 
 #endif

--- a/src/AwsSignatureHandlerSettings.cs
+++ b/src/AwsSignatureHandlerSettings.cs
@@ -56,6 +56,27 @@ namespace AwsSignatureVersion4
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="AwsSignatureHandlerSettings"/> class
+        /// without explicit credentials. Credentials will instead be resolved, just before each
+        /// request is signed, using the default AWS credential search order, i.e. the same order
+        /// used by <see cref="Amazon.Runtime.Credentials.DefaultAWSCredentialsIdentityResolver"/>,
+        /// which includes environment variables, shared AWS credentials/config files, and
+        /// container/EC2 instance profile credentials.
+        /// </summary>
+        /// <param name="regionName">
+        /// The system name of the AWS region associated with the endpoint, e.g. "us-east-1".
+        /// </param>
+        /// <param name="serviceName">
+        /// The signing name of the service, e.g. "execute-api".
+        /// </param>
+        public AwsSignatureHandlerSettings(string regionName, string serviceName)
+        {
+            RegionName = regionName ?? throw new ArgumentNullException(nameof(regionName));
+            ServiceName = serviceName ?? throw new ArgumentNullException(nameof(serviceName));
+            Credentials = null;
+        }
+
+        /// <summary>
         /// Gets the system name of the AWS region associated with the endpoint, e.g. "us-east-1".
         /// </summary>
         internal string RegionName { get; }
@@ -71,7 +92,9 @@ namespace AwsSignatureVersion4
         /// - The AWS secret key for the account making the call, in clear text.
         /// - The session token obtained from STS if request is authenticated using temporary
         ///   security credentials, e.g. a role.
+        /// Null indicates that credentials should be resolved using the default AWS credential
+        /// search order.
         /// </summary>
-        internal AWSCredentials Credentials { get; }
+        internal AWSCredentials? Credentials { get; }
     }
 }

--- a/test/Unit/AwsSignatureHandlerShould.cs
+++ b/test/Unit/AwsSignatureHandlerShould.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Reflection;
@@ -156,6 +157,82 @@ namespace AwsSignatureVersion4.Unit
 
         #endregion
 
+        #region Default credentials
+
+        [Fact]
+        public async Task SetHeadersUsingDefaultCredentialsAsync()
+        {
+            // Arrange
+            using var environment = new EnvironmentCredentialsScope();
+
+            var handler = new AwsSignatureHandler(new AwsSignatureHandlerSettings("us-east-1", "execute-api"))
+            {
+                InnerHandler = sinkHandler
+            };
+
+            var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                new Uri("https://example.amazonaws.com/resource/path"));
+
+            var ct = new CancellationToken();
+
+            // Act
+            await InvokeSendAsync(handler, request, ct);
+
+            // Assert
+            sinkHandler.Request.Headers.Contains(HeaderKeys.AuthorizationHeader).ShouldBeTrue();
+            sinkHandler
+                .Request
+                .Headers
+                .GetValues(HeaderKeys.AuthorizationHeader)
+                .Single()
+                .ShouldContain(environment.AccessKeyId);
+            sinkHandler
+                .Request
+                .Headers
+                .GetValues(HeaderKeys.XAmzSecurityTokenHeader)
+                .Single()
+                .ShouldBe(environment.SessionToken);
+        }
+
+        [Fact]
+        public void SetHeadersUsingDefaultCredentials()
+        {
+            // Arrange
+            using var environment = new EnvironmentCredentialsScope();
+
+            var handler = new AwsSignatureHandler(new AwsSignatureHandlerSettings("us-east-1", "execute-api"))
+            {
+                InnerHandler = sinkHandler
+            };
+
+            var request = new HttpRequestMessage(
+                HttpMethod.Get,
+                new Uri("https://example.amazonaws.com/resource/path"));
+
+            var ct = new CancellationToken();
+
+            // Act
+            InvokeSend(handler, request, ct);
+
+            // Assert
+            sinkHandler.Request.Headers.Contains(HeaderKeys.AuthorizationHeader).ShouldBeTrue();
+            sinkHandler
+                .Request
+                .Headers
+                .GetValues(HeaderKeys.AuthorizationHeader)
+                .Single()
+                .ShouldContain(environment.AccessKeyId);
+            sinkHandler
+                .Request
+                .Headers
+                .GetValues(HeaderKeys.XAmzSecurityTokenHeader)
+                .Single()
+                .ShouldBe(environment.SessionToken);
+        }
+
+        #endregion
+
         private static AwsSignatureHandlerSettings CreateSettings(string serviceName) =>
             new(
                 "us-east-1",
@@ -201,6 +278,48 @@ namespace AwsSignatureVersion4.Unit
                 Request = request;
 
                 return new HttpResponseMessage(HttpStatusCode.OK);
+            }
+        }
+
+        /// <summary>
+        /// Sets the AWS environment variable credentials for the duration of the scope, and
+        /// restores the previous values on disposal. Used to exercise the default AWS credential
+        /// search order deterministically, without relying on the test environment already
+        /// having credentials configured.
+        /// </summary>
+        private class EnvironmentCredentialsScope : IDisposable
+        {
+            private const string AccessKeyIdVariable = "AWS_ACCESS_KEY_ID";
+            private const string SecretAccessKeyVariable = "AWS_SECRET_ACCESS_KEY";
+            private const string SessionTokenVariable = "AWS_SESSION_TOKEN";
+
+            private readonly string previousAccessKeyId;
+            private readonly string previousSecretAccessKey;
+            private readonly string previousSessionToken;
+
+            public EnvironmentCredentialsScope()
+            {
+                previousAccessKeyId = Environment.GetEnvironmentVariable(AccessKeyIdVariable);
+                previousSecretAccessKey = Environment.GetEnvironmentVariable(SecretAccessKeyVariable);
+                previousSessionToken = Environment.GetEnvironmentVariable(SessionTokenVariable);
+
+                AccessKeyId = $"some access key id {Guid.NewGuid()}";
+                SessionToken = $"some token {Guid.NewGuid()}";
+
+                Environment.SetEnvironmentVariable(AccessKeyIdVariable, AccessKeyId);
+                Environment.SetEnvironmentVariable(SecretAccessKeyVariable, "some secret access key");
+                Environment.SetEnvironmentVariable(SessionTokenVariable, SessionToken);
+            }
+
+            public string AccessKeyId { get; }
+
+            public string SessionToken { get; }
+
+            public void Dispose()
+            {
+                Environment.SetEnvironmentVariable(AccessKeyIdVariable, previousAccessKeyId);
+                Environment.SetEnvironmentVariable(SecretAccessKeyVariable, previousSecretAccessKey);
+                Environment.SetEnvironmentVariable(SessionTokenVariable, previousSessionToken);
             }
         }
     }


### PR DESCRIPTION
Fixes #1529

`AwsSignatureHandlerSettings` previously required an `AWSCredentials`/`ImmutableCredentials` instance to be supplied up front. This meant callers had to resolve AWS credential configuration even in code paths - like tests - that construct the settings/handler but never make a call that actually needs signing.

This PR:
- Adds an `AwsSignatureHandlerSettings(string regionName, string serviceName)` constructor overload that leaves credentials unset (nullable `Credentials` property).
- Updates `AwsSignatureHandler.SendAsync`/`Send` to fall back to `Amazon.Runtime.Credentials.DefaultAWSCredentialsIdentityResolver` only when actually signing a request, i.e. resolution is deferred to request time rather than happening at construction.
- Adds unit tests exercising the default-credential fallback via injected environment-variable credentials.

`DefaultAWSCredentialsIdentityResolver` caches internally and only re-resolves on environment/credential-file changes, so calling it per-request is cheap - matching how AWS SDK v4 service clients (e.g. `AmazonS3Client()`) resolve credentials lazily rather than at construction.
